### PR TITLE
Removed bug preventing multiple attacks from a single character

### DIFF
--- a/ZombieWar/src/zombiewar/ZombieWarController.java
+++ b/ZombieWar/src/zombiewar/ZombieWarController.java
@@ -77,7 +77,6 @@ public class ZombieWarController {
                           if(!zombieArmy[j].isAlive()) {
                             zombieArmySize -= 1;
                           }
-                          break;
                        }                   
                    }
                }
@@ -98,7 +97,6 @@ public class ZombieWarController {
                             if(!humanArmy[j].isAlive()) {
                                 humanArmySize -= 1;
                             }
-                            break;
                         }
                     }
 


### PR DESCRIPTION
Removes breaks that disrupted the flow of attack loops, causing a bug in which one character did not attack all opponents.